### PR TITLE
Implement demangler for Rust

### DIFF
--- a/src/rust.c
+++ b/src/rust.c
@@ -3,15 +3,27 @@
 #include "demangler_util.h"
 #include <rz_libdemangle.h>
 
-uint32_t get_integer(const char **str) {
-	/* Assuming the string in str is base 10 */
+uint32_t rebase_value(uint8_t char_code, uint8_t base) {
+	if ((char_code >= 'a' && char_code <= 'z') || (char_code >= 'A' && char_code <= 'Z')) {
+		/* lower/upper case letter */
+		return (char_code | 0x20) - 'a' + 10;
+	} else if (char_code >= '0' && char_code <= '9') {
+		/* integer character */
+		return char_code & 0xf;
+	} else {
+		/* invalid */
+		return base;
+	}
+}
 
+uint32_t get_integer(const char **str, uint8_t base) {
 	uint32_t result = 0;
 	const char *x = *str;
+	uint8_t digit;
 
-	while (IS_DIGIT(*x)) {
-		result *= 10;
-		result += *x & 0xf;
+	while ((digit = rebase_value(*x, base)) < base) {
+		result *= base;
+		result += digit;
 		x++;
 	}
 
@@ -21,8 +33,97 @@ uint32_t get_integer(const char **str) {
 	return result;
 }
 
+uint32_t utf_to_bytes(uint32_t utf) {
+	/* returns in big endian */
+	uint32_t result = 0;
+
+	if (utf < 0x80) {
+		result = utf << 24;
+	} else if (utf < 0x800) {
+		result = (utf & 0x3f) << 16;
+		result |= ((utf >> 6) & 0x1f) << 24;
+		result |= 0xc0800000;
+	} else if (utf < 0x10000) {
+		result = (utf & 0x3f) << 8;
+		result |= ((utf >> 6) & 0x3f) << 16;
+		result |= ((utf >> 12) & 0xf) << 24;
+		result |= 0xe0808000;
+	} else if (utf < 0x110000) {
+		result = utf & 0x3f;
+		result |= ((utf >> 6) & 0x3f) << 8;
+		result |= ((utf >> 12) & 0x3f) << 16;
+		result |= ((utf >> 18) & 0x7) << 24;
+		result |= 0xf0808080;
+	}
+
+	return result;
+}
+
+DemString *replace_utf(const char *utf_str) {
+	DemString *demstr = dem_string_new();
+	const char *utf_char = strchr(utf_str, '$');
+	const char *last_ptr = utf_str;
+
+	while (utf_char) {
+		if (*(utf_char + 1) != 'u') {
+			utf_char++;
+			goto next_delim;
+		}
+
+		dem_string_append_n(demstr, last_ptr, utf_char - last_ptr);
+		utf_char += 2;
+
+		uint32_t utf_int = get_integer((const char **)&utf_char, 16);
+		uint32_t utf_bytes = utf_to_bytes(utf_int);
+		if (utf_bytes) {
+			const char bytes_str[5] = { (utf_bytes >> 24) & 0xff, (utf_bytes >> 16) & 0xff,
+				(utf_bytes >> 8) & 0xff, utf_bytes & 0xff,
+				'\0' };
+			dem_string_append(demstr, bytes_str);
+			/* Consume closing $ */
+			utf_char += 1;
+		} else {
+			/* Not a UTF character (unreachable, but just in case) */
+			dem_string_append(demstr, "$u");
+		}
+
+		last_ptr = utf_char;
+
+	next_delim:
+		utf_char = strchr(utf_char, '$');
+	}
+
+	dem_string_append(demstr, last_ptr);
+	return demstr;
+}
+
+static char *special_symbols[] = {
+	"$SP$",
+	"$BP$",
+	"$RF$",
+	"$LT$",
+	"$GT$",
+	"$LP$",
+	"$RP$",
+	"$C$",
+	/* namespace */
+	".."
+};
+
+static char *replacements[] = {
+	"@",
+	"*",
+	"&",
+	"<",
+	">",
+	"(",
+	")",
+	",",
+	"::"
+};
+
 /**
- * @brief We return NULL instead of strdup-ing the string, because that way we can check for NULL
+ * \brief We return NULL instead of strdup-ing the string, because that way we can check for NULL
  * and invoke the CXX demangler \p sym again in case it a CXX symbol
  * We should not call the CXX demangler here because then this code will not be LGPL,
  * but GPL because CXX demangler is GPL
@@ -56,7 +157,7 @@ char *libdemangle_handler_rust(const char *sym) {
 	DemString *result = dem_string_new();
 
 	while (*post != 'E') {
-		uint32_t len = get_integer(&post);
+		uint32_t len = get_integer(&post, 10);
 
 		/* Check if no digits found
 		OR If end of string reached
@@ -67,6 +168,11 @@ char *libdemangle_handler_rust(const char *sym) {
 			return NULL;
 		}
 
+		if (!strncmp(post, "_$", strlen("_$"))) {
+			/* special symbols can have an extra underscore before it, if first in token */
+			post++;
+			len--;
+		}
 		dem_string_append_n(result, post, len);
 		post += len;
 
@@ -75,5 +181,43 @@ char *libdemangle_handler_rust(const char *sym) {
 		}
 	}
 
-	return dem_string_drain(result);
+	char *demangled = dem_string_drain(result);
+	for (uint8_t i = 0; i < sizeof(special_symbols) / sizeof(special_symbols[0]); i++) {
+		dem_str_replace(demangled, special_symbols[i], replacements[i], 1);
+	}
+
+	DemString *utf_free = replace_utf(demangled);
+	free(demangled);
+
+	/* ThinLTO LLVM IR period delimited suffixes */
+	const char *suff = post + 1;
+	uint8_t llvm_len = strlen(".llvm.");
+	const char *llvm_str = NULL;
+	bool found_llvm = false, check_hex = false;
+
+	while (*++post > 0x20) {
+		if (check_hex && !(*post >= 'A' || *post <= 'Z' || *post >= '0' || *post <= '9')) {
+			check_hex = false;
+		}
+		if (!found_llvm && !strncmp(post, ".llvm.", llvm_len)) {
+			found_llvm = true;
+			check_hex = true;
+			llvm_str = post;
+			post += llvm_len - 1;
+			continue;
+		}
+	}
+	if (*post != 0x00) {
+		/* Invalid character found in suffix (post did not end yet) */
+		dem_string_free(utf_free);
+		return NULL;
+	}
+
+	if (llvm_str && check_hex) {
+		/* Valid LLVM suffix found, then ignore it */
+		post = llvm_str;
+	}
+
+	dem_string_append_n(utf_free, suff, post - suff);
+	return dem_string_drain(utf_free);
 }

--- a/src/rust.c
+++ b/src/rust.c
@@ -3,78 +3,77 @@
 #include "demangler_util.h"
 #include <rz_libdemangle.h>
 
-#define RS(from, to) \
-	if (replace_seq((const char **)&in, &out, (const char *)(from), to)) \
-	continue
+uint32_t get_integer(const char **str) {
+	/* Assuming the string in str is base 10 */
 
-static bool replace_seq(const char **in, char **out, const char *seq, char value) {
-	size_t len = strlen(seq);
+	uint32_t result = 0;
+	const char *x = *str;
 
-	if (strncmp(*in, seq, len)) {
-		return false;
+	while (IS_DIGIT(*x)) {
+		result *= 10;
+		result += *x & 0xf;
+		x++;
 	}
 
-	**out = value;
+	/* Update the string pointer */
+	*str = x;
 
-	*in += len;
-	*out += 1;
-
-	return true;
+	return result;
 }
 
+/**
+ * @brief We return NULL instead of strdup-ing the string, because that way we can check for NULL
+ * and invoke the CXX demangler \p sym again in case it a CXX symbol
+ * We should not call the CXX demangler here because then this code will not be LGPL,
+ * but GPL because CXX demangler is GPL
+ */
 char *libdemangle_handler_rust(const char *sym) {
-	int len;
-	char *str = NULL, *out, *in;
+	const char *post = sym;
+	char *prefixes[] = { "_ZN", /* Windows */ "ZN", /* OSX */ "__ZN" };
 
-	str = libdemangle_handler_cxx(sym);
-
-	if (!str) {
-		return str;
-	}
-
-	out = in = str;
-	len = strlen(str);
-
-	if (*in == '_') {
-		in++;
-		len--;
-	}
-
-	while ((len = strlen(in)) > 0) {
-		if (*in == '$') {
-			RS("$SP$", '@');
-			RS("$BP$", '*');
-			RS("$RF$", '&');
-			RS("$LT$", '<');
-			RS("$GT$", '>');
-			RS("$LP$", '(');
-			RS("$RP$", ')');
-			RS("$C$", ',');
-			// maybe a good idea to replace all utf-sequences by regexp \$u[0-9a-f]{2}\$ or so
-			RS("$u20$", ' ');
-			RS("$u22$", '\"');
-			RS("$u27$", '\'');
-			RS("$u2b$", '+');
-			RS("$u3b$", ';');
-			RS("$u5b$", '[');
-			RS("$u5d$", ']');
-			RS("$u7e$", '~');
-		}
-		if (*in == '.') {
-			if (len > 0 && in[1] == '.') {
-				in += 2;
-				*out++ = ':';
-				*out++ = ':';
-				len--;
-			} else {
-				in += 1;
-				*out = '-';
-			}
-		} else {
-			*out++ = *in++;
+	for (uint8_t i = 0; i < sizeof(prefixes) / sizeof(prefixes[0]); i++) {
+		uint8_t len = strlen(prefixes[i]);
+		if (!strncmp(sym, prefixes[i], len)) {
+			post += len;
+			break;
 		}
 	}
-	*out = '\0';
 
-	return str;
+	if (sym == post) {
+		/* Not a Rust symbol */
+		return NULL;
+	}
+
+	const char *itr = post;
+	while (*itr) {
+		/* Check if only ASCII chars present */
+		if (*itr & 0x80) {
+			return NULL;
+		}
+		itr++;
+	}
+
+	DemString *result = dem_string_new();
+
+	while (*post != 'E') {
+		uint32_t len = get_integer(&post);
+
+		/* Check if no digits found
+		OR If end of string reached
+		OR Element ends after (or when) the string ends */
+		if (len == 0 || *post == '\0' || len >= strlen(post)) {
+			/* All these cases are malformed */
+			dem_string_free(result);
+			return NULL;
+		}
+
+		dem_string_append_n(result, post, len);
+		post += len;
+
+		if (*post != 'E') {
+			dem_string_append(result, "::");
+		}
+	}
+
+	return dem_string_drain(result);
 }

--- a/src/rust.c
+++ b/src/rust.c
@@ -4,7 +4,7 @@
 #include "demangler_util.h"
 #include <rz_libdemangle.h>
 
-uint32_t rebase_value(uint8_t char_code, uint8_t base) {
+static uint32_t rebase_value(uint8_t char_code, uint8_t base) {
 	if ((char_code >= 'a' && char_code <= 'z') || (char_code >= 'A' && char_code <= 'Z')) {
 		/* lower/upper case letter */
 		return (char_code | 0x20) - 'a' + 10;
@@ -17,7 +17,7 @@ uint32_t rebase_value(uint8_t char_code, uint8_t base) {
 	}
 }
 
-uint32_t get_integer(const char **str, uint8_t base) {
+static uint32_t get_integer(const char **str, uint8_t base) {
 	uint32_t result = 0;
 	const char *x = *str;
 	uint8_t digit;
@@ -34,7 +34,7 @@ uint32_t get_integer(const char **str, uint8_t base) {
 	return result;
 }
 
-uint32_t utf_to_bytes(uint32_t utf) {
+static uint32_t utf_to_bytes(uint32_t utf) {
 	/* returns in big endian */
 	uint32_t result = 0;
 
@@ -60,7 +60,7 @@ uint32_t utf_to_bytes(uint32_t utf) {
 	return result;
 }
 
-DemString *replace_utf(const char *utf_str) {
+static DemString *replace_utf(const char *utf_str) {
 	DemString *demstr = dem_string_new();
 	const char *utf_char = strchr(utf_str, '$');
 	const char *last_ptr = utf_str;

--- a/src/rust.c
+++ b/src/rust.c
@@ -1,5 +1,6 @@
-// SPDX-FileCopyrightText: 2011-2018 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2023 Dhruv Maroo <dhruvmaru007@gmail.com>
 // SPDX-License-Identifier: LGPL-3.0-only
+
 #include "demangler_util.h"
 #include <rz_libdemangle.h>
 

--- a/test/test_rust.c
+++ b/test/test_rust.c
@@ -3,6 +3,8 @@
 
 #include "demangling_unit.h"
 
+#define TEST_COUNT 12
+
 mu_demangle(0, rust, "_ZN5alloc3oom3oom17h722648b727b8bcd0E", "alloc::oom::oom::h722648b727b8bcd0");
 mu_demangle(1, rust, "__ZN4core3fmt5Write10write_char17hcc5144a9a84f2b15E", "core::fmt::Write::write_char::hcc5144a9a84f2b15");
 mu_demangle(2, rust, "ZN14rustc_demangle6legacy8demangleE", "rustc_demangle::legacy::demangle");
@@ -10,6 +12,51 @@ mu_demangle(3, rust, "_ZN4toolongE", NULL);
 mu_demangle(4, rust, "___ZNwrong_formatE", NULL);
 mu_demangle(5, rust, "_ZN10no_e_found", NULL);
 mu_demangle(6, rust, "_ZN7onlyone", NULL);
+mu_demangle(7, rust, "_ZN4$RP$E", ")");
+mu_demangle(8, rust, "_ZN8$RF$testE", "&test");
+mu_demangle(9, rust, "_ZN8$BP$test4foobE", "*test::foob");
+mu_demangle(10, rust, "_ZN9$u20$test4foobE", " test::foob");
+mu_demangle(11, rust, "_ZN35Bar$LT$$u5b$u32$u3b$$u20$4$u5d$$GT$E", "Bar<[u32; 4]>");
+mu_demangle(12, rust, "_ZN13test$u20$test4foobE", "test test::foob");
+mu_demangle(13, rust, "_ZN12test$BP$test4foobE", "test*test::foob");
+mu_demangle(14, rust, "__ZN5alloc9allocator6Layout9for_value17h02a996811f781011E", "alloc::allocator::Layout::for_value::h02a996811f781011");
+mu_demangle(15, rust, "__ZN38_$LT$core..option..Option$LT$T$GT$$GT$6unwrap18_MSG_FILE_LINE_COL17haf7cb8d5824ee659E", "<core::option::Option<T>>::unwrap::_MSG_FILE_LINE_COL::haf7cb8d5824ee659");
+mu_demangle(16, rust, "__ZN4core5slice89_$LT$impl$u20$core..iter..traits..IntoIterator$u20$for$u20$$RF$$u27$a$u20$$u5b$T$u5d$$GT$9into_iter17h450e234d27262170E", "core::slice::<impl core::iter::traits::IntoIterator for &'a [T]>::into_iter::h450e234d27262170");
+mu_demangle(17, rust, "ZN4testE", "test");
+mu_demangle(18, rust, "ZN13test$u20$test4foobE", "test test::foob");
+mu_demangle(19, rust, "ZN12test$RF$test4foobE", "test&test::foob");
+mu_demangle(20, rust, "_ZN13_$LT$test$GT$E", "<test>");
+mu_demangle(21, rust, "_ZN28_$u7b$$u7b$closure$u7d$$u7d$E", "{{closure}}");
+mu_demangle(22, rust, "_ZN15__STATIC_FMTSTRE", "__STATIC_FMTSTR");
+mu_demangle(23, rust, "_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE", "<Test + 'static as foo::Bar<Test>>::bar");
+mu_demangle(24, rust, "_ZN3foo17h05af221e174051e9E", "foo::h05af221e174051e9");
+mu_demangle(25, rust, "_ZN3fooE", "foo");
+mu_demangle(26, rust, "_ZN3foo3barE", "foo::bar");
+mu_demangle(27, rust, "_ZN3foo20h05af221e174051e9abcE", "foo::h05af221e174051e9abc");
+mu_demangle(28, rust, "_ZN3foo5h05afE", "foo::h05af");
+mu_demangle(29, rust, "_ZN17h05af221e174051e93fooE", "h05af221e174051e9::foo");
+mu_demangle(30, rust, "_ZN3foo16ffaf221e174051e9E", "foo::ffaf221e174051e9");
+mu_demangle(31, rust, "_ZN3foo17hg5af221e174051e9E", "foo::hg5af221e174051e9");
+mu_demangle(32, rust, "_ZN3fooE.llvm.9D1C9369", "foo");
+mu_demangle(33, rust, "_ZN3fooE.llvm.9D1C9369@@16", "foo");
+mu_demangle(34, rust, "_ZN9backtrace3foo17hbb467fcdaea5d79bE.llvm.A5310EB9", "backtrace::foo::hbb467fcdaea5d79b");
+mu_demangle(35, rust, "_ZN4core5slice77_$LT$impl$u20$core..ops..index..IndexMut$LT$I$GT$$u20$for$u20$$u5b$T$u5d$$GT$9index_mut17haf9727c2edfbc47bE.exit.i.i", "core::slice::<impl core::ops::index::IndexMut<I> for [T]>::index_mut::haf9727c2edfbc47b.exit.i.i");
+mu_demangle(36, rust, "_ZN3fooE.llvm moocow", NULL);
+mu_demangle(37, rust, "_ZN2222222222222222222222EE", NULL);
+mu_demangle(38, rust, "_ZN5*70527e27.ll34csaғE", NULL);
+mu_demangle(39, rust, "_ZN5*70527a54.ll34_$b.1E", NULL);
+mu_demangle(40, rust,
+	"\
+        _ZN5~saäb4e\n\
+        2734cOsbE\n\
+        5usage20h)3\0\0\0\0\0\0\07e2734cOsbE\
+        ",
+	NULL);
+mu_demangle(41, rust, "_ZNfooE", NULL);
+mu_demangle(42, rust, "_ZN151_$LT$alloc..boxed..Box$LT$alloc..boxed..FnBox$LT$A$C$$u20$Output$u3d$R$GT$$u20$$u2b$$u20$$u27$a$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$9call_once17h69e8f44b3723e1caE", "<alloc::boxed::Box<alloc::boxed::FnBox<A, Output=R> + 'a> as core::ops::function::FnOnce<A>>::call_once::h69e8f44b3723e1ca");
+mu_demangle(43, rust, "_ZN88_$LT$core..result..Result$LT$$u21$$C$$u20$E$GT$$u20$as$u20$std..process..Termination$GT$6report17hfc41d0da4a40b3e8E", "<core::result::Result<!, E> as std::process::Termination>::report::hfc41d0da4a40b3e8");
+mu_demangle(44, rust, "_ZN11utf8_idents157_$u10e1$$u10d0$$u10ed$$u10db$$u10d4$$u10da$$u10d0$$u10d3$_$u10d2$$u10d4$$u10db$$u10e0$$u10d8$$u10d4$$u10da$$u10d8$_$u10e1$$u10d0$$u10d3$$u10d8$$u10da$$u10d8$17h21634fd5714000aaE", "utf8_idents::საჭმელად_გემრიელი_სადილი::h21634fd5714000aa");
+mu_demangle(45, rust, "_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$3foo17h059a991a004536adE", "issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo::h059a991a004536ad");
 
 int all_tests() {
 	mu_demangle_run(0);
@@ -19,6 +66,46 @@ int all_tests() {
 	mu_demangle_run(4);
 	mu_demangle_run(5);
 	mu_demangle_run(6);
+	mu_demangle_run(7);
+	mu_demangle_run(8);
+	mu_demangle_run(9);
+	mu_demangle_run(10);
+	mu_demangle_run(11);
+	mu_demangle_run(12);
+	mu_demangle_run(13);
+	mu_demangle_run(14);
+	mu_demangle_run(15);
+	mu_demangle_run(16);
+	mu_demangle_run(17);
+	mu_demangle_run(18);
+	mu_demangle_run(19);
+	mu_demangle_run(20);
+	mu_demangle_run(21);
+	mu_demangle_run(22);
+	mu_demangle_run(23);
+	mu_demangle_run(24);
+	mu_demangle_run(25);
+	mu_demangle_run(26);
+	mu_demangle_run(27);
+	mu_demangle_run(28);
+	mu_demangle_run(29);
+	mu_demangle_run(30);
+	mu_demangle_run(31);
+	mu_demangle_run(32);
+	mu_demangle_run(33);
+	mu_demangle_run(34);
+	mu_demangle_run(35);
+	mu_demangle_run(36);
+	mu_demangle_run(37);
+	mu_demangle_run(38);
+	mu_demangle_run(39);
+	mu_demangle_run(40);
+	mu_demangle_run(41);
+	mu_demangle_run(42);
+	mu_demangle_run(43);
+	mu_demangle_run(44);
+	mu_demangle_run(45);
+
 	return tests_passed != tests_run;
 }
 

--- a/test/test_rust.c
+++ b/test/test_rust.c
@@ -3,11 +3,13 @@
 
 #include "demangling_unit.h"
 
-mu_demangle(0, rust, "_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEED1Ev", "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()");
-mu_demangle(1, rust, "_ZN5alloc3oom3oom17h722648b727b8bcd0E", "alloc::oom::oom::h722648b727b8bcd0");
-mu_demangle(2, rust, "_ZN4core3fmt5Write10write_char17hcc5144a9a84f2b15E", "core::fmt::Write::write_char::hcc5144a9a84f2b15");
-mu_demangle(3, rust, "_ZN71_$LT$Test$u20$$u2b$$u20$$u27$static$u20$as$u20$foo..Bar$LT$Test$GT$$GT$3barE", "<Test + 'static as foo::Bar<Test>>::bar");
-mu_demangle(4, rust, "_ZN96_$LT$core..fmt..Write..write_fmt..Adapter$LT$$u27$a$C$$u20$T$GT$$u20$as$u20$core..fmt..Write$GT$9write_str17he4f4768a2f446facE", "<core::fmt::Write::write_fmt::Adapter<'a, T> as core::fmt::Write>::write_str::he4f4768a2f446fac");
+mu_demangle(0, rust, "_ZN5alloc3oom3oom17h722648b727b8bcd0E", "alloc::oom::oom::h722648b727b8bcd0");
+mu_demangle(1, rust, "__ZN4core3fmt5Write10write_char17hcc5144a9a84f2b15E", "core::fmt::Write::write_char::hcc5144a9a84f2b15");
+mu_demangle(2, rust, "ZN14rustc_demangle6legacy8demangleE", "rustc_demangle::legacy::demangle");
+mu_demangle(3, rust, "_ZN4toolongE", NULL);
+mu_demangle(4, rust, "___ZNwrong_formatE", NULL);
+mu_demangle(5, rust, "_ZN10no_e_found", NULL);
+mu_demangle(6, rust, "_ZN7onlyone", NULL);
 
 int all_tests() {
 	mu_demangle_run(0);
@@ -15,6 +17,8 @@ int all_tests() {
 	mu_demangle_run(2);
 	mu_demangle_run(3);
 	mu_demangle_run(4);
+	mu_demangle_run(5);
+	mu_demangle_run(6);
 	return tests_passed != tests_run;
 }
 


### PR DESCRIPTION
The demangler still wouldn't work for the executable specified in #30, but that is because of rizinorg/rizin#3404. The demangler is correct and complete, as evidenced in the tests.

Partially fixes #30.