### PR TITLE
[gnuv2] Fix multiplication overflow check due compiler optimizations

### DIFF
--- a/src/gnu_v2/cplus-dem.c
+++ b/src/gnu_v2/cplus-dem.c
@@ -420,7 +420,10 @@ static int
 	consume_count(type)
 		const char **type;
 {
-	int count = 0;
+	// Note by RizinOrg:
+	// to prevent the overflow check to be optimized out
+	// by the compiler, this variable needs to be volatile.
+	volatile int count = 0;
 
 	if (!isdigit((unsigned char)**type))
 		return -1;

--- a/test/test_cxx_gnu_v2.c
+++ b/test/test_cxx_gnu_v2.c
@@ -4,6 +4,9 @@
 #include "minunit.h"
 
 mu_demangle_tests(gnu_v2,
+	// fuzzed strings
+	mu_demangle_test("_ITM_deregisterTMCCCCCCCCCCCCCCCCCCCtart__5555555555555555CloneTable", NULL),
+	// normal
 	mu_demangle_test("_vt.foo", "foo virtual table"),
 	mu_demangle_test("_vt$foo", "foo virtual table"),
 	mu_demangle_test("_vt$foo$bar", "foo::bar virtual table"),


### PR DESCRIPTION
# DO NOT SQUASH, just rebase

Fixes a security vulnerability located in the `libiberty/cplus-dem.c` for the old `gnu v2` format (not used anymore).