### PR TITLE
ci: Upgrade to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Normal:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
         ./test/test-cli.sh ./build/demangle
 
   Normal-No-GPL:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
         ./test/test-cli.sh ./build-nogpl/demangle
 
   Normal-Minimal:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -50,7 +50,7 @@ jobs:
         ./test/test-cli.sh ./build-no-min/demangle
 
   Asan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   licenses:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
This pr upgrades the Ubuntu image used in the CI to `ubuntu-22.04`, which is the same version used in Rizin's CI.