### PR TITLE
Move stdarg.h include to demangler_util.h from demangler_util.c

### DIFF
--- a/src/demangler_util.c
+++ b/src/demangler_util.c
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 #include "demangler_util.h"
-#include <stdarg.h>
 /* These are mostly copied from rz_util till the util itself is not a side lib */
 
 #define dem_return_val_if_fail(expr, val) \

--- a/src/demangler_util.h
+++ b/src/demangler_util.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <inttypes.h>


### PR DESCRIPTION
Moves `stdarg.h` include to `demangler_util.h` from `demangler_util.c` to fix include errors and recognize `va_list` properly on OpenBSD and NetBSD